### PR TITLE
feat: Add docker support.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+build/
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:14-alpine AS builder
+
+WORKDIR /app
+COPY . /app
+RUN yarn install && yarn build
+
+FROM nginx:stable-alpine
+COPY --from=builder /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -7,13 +7,28 @@
 
 在线地址: https://resume.mdedit.online/
 
-## 开始
+## 开始使用
+
+### Docker 使用 | 推荐
+
+> 使用 docker 运行，默认本地已经拥有可运行的 docker 环境
+
+使用 `Terminal` 终端，运行下面命令
+
+```sh
+$ docker run --rm -d -p 3000:80 yanzhiwei147/muji
+```
+
+打开 [`http://localhost:3000/`](http://localhost:3000/)
+
+### 源码使用
 
 ```
-yarn install
-yarn start 
+$ git clone https://github.com/hua1995116/react-resume-site.git && cd react-resume-site
+$ yarn install && yarn start 
 ```
-打开 http://localhost:3000/
+
+打开 [`http://localhost:3000/`](http://localhost:3000/)
 
 ## 贡献
 


### PR DESCRIPTION
关联 #11

支持 docker 镜像。

- 设计上只是简单支持试用，并未做 volume 映射。
- docker hub team 需要付费，因此暂时将构建的镜像放置到我名下，作者如果有疑虑可以考虑创建自己的 repo 并构建上传。