### PR TITLE
fix: Editor useRef type error

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/react-router-dom": "^5.1.7",
     "@typescript-eslint/eslint-plugin": "^4.5.0",
     "@typescript-eslint/parser": "^4.5.0",
-    "@uiw/react-codemirror": "^3.0.5",
+    "@uiw/react-codemirror": "^3.2.1",
     "antd": "^4.12.3",
     "axios": "^0.21.1",
     "babel-eslint": "^10.1.0",

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect } from "react";
-import CodeMirror from "@uiw/react-codemirror";
+import CodeMirror, { IEditorInstance } from "@uiw/react-codemirror";
 import debounce from "lodash-es/debounce";
 import { useStores } from "@src/store";
 import { setMdHistory, setMdEditorRef, globalEditorCountIncrease, globalEditorCount, setHtmlView } from "@src/utils/global";
@@ -19,7 +19,7 @@ let timerSave: TimerSave = null;
 const Editor: React.FC<Props> = observer((props) => {
   const { templateStore } = useStores();
   const { isPreview, mdContent, setHtml } = templateStore;
-  const editorRef = useRef<CodeMirror>(null);
+  const editorRef = useRef<IEditorInstance>(null);
   // console.log(color, theme, '===editor');
   useEffect(() => {
     // 由于子元素是 useEffect 中初始化，因此正常无法获取，需要延迟
@@ -30,7 +30,7 @@ const Editor: React.FC<Props> = observer((props) => {
 
   return (
     <>
-      <div className="rs-editor-cover" style={{display: isPreview ? 'flex' : 'none'}}>预览中，不可编辑</div>
+      <div className="rs-editor-cover" style={{ display: isPreview ? 'flex' : 'none' }}>预览中，不可编辑</div>
       <CodeMirror
         ref={editorRef}
         value={mdContent}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,7 +1154,14 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@7.13.10", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.1", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.1", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@7.15.3":
+  version "7.15.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.3.tgz#2e1c2880ca118e5b2f9988322bd8a7656a32502b"
+  integrity sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.1", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.1", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.13.10"
   resolved "https://registry.npm.taobao.org/@babel/runtime/download/@babel/runtime-7.13.10.tgz?cache=0&sync_timestamp=1615243220467&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fruntime%2Fdownload%2F%40babel%2Fruntime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
   integrity sha1-R9QqV7YJX0Ro2kQDiP262L6/DX0=
@@ -2149,12 +2156,12 @@
     eslint-visitor-keys "^2.0.0"
 
 "@uiw/react-codemirror@^3.0.5":
-  version "3.0.6"
-  resolved "https://registry.npm.taobao.org/@uiw/react-codemirror/download/@uiw/react-codemirror-3.0.6.tgz#62a2d2a9e970be07e091268adc71129a36d5ba2e"
-  integrity sha1-YqLSqelwvgfgkSaK3HESmjbVui4=
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@uiw/react-codemirror/-/react-codemirror-3.2.1.tgz#355fda3a23143a9dcac23309397db95c90126630"
+  integrity sha512-taciFidmB/V8ve5SElMnMsRNwTVWCwTK16dsP9RIfPbbourVnmt9Tb+FIoeA6Jdlej4M9nr4X9IXtaw/GmqDPg==
   dependencies:
-    "@babel/runtime" "7.13.10"
-    codemirror "5.60.0"
+    "@babel/runtime" "7.15.3"
+    codemirror "5.62.3"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -3810,10 +3817,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.npm.taobao.org/code-point-at/download/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codemirror@5.60.0:
-  version "5.60.0"
-  resolved "https://registry.npm.taobao.org/codemirror/download/codemirror-5.60.0.tgz#00a8cfd287d5d8737ceb73987f04aee2fe5860da"
-  integrity sha1-AKjP0ofV2HN863OYfwSu4v5YYNo=
+codemirror@5.62.3:
+  version "5.62.3"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.62.3.tgz#5cfdee6931c8b2d1b39ae773aaaaec2cc6b5558e"
+  integrity sha512-zZAyOfN8TU67ngqrxhOgtkSAGV9jSpN1snbl8elPtnh9Z5A11daR405+dhLzLnuXrwX0WCShWlybxPN3QC/9Pg==
 
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
@@ -10893,7 +10900,12 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.npm.taobao.org/regenerator-runtime/download/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=
 
-regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
+regenerator-runtime@^0.13.4:
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
+  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
+
+regenerator-runtime@^0.13.7:
   version "0.13.7"
   resolved "https://registry.npm.taobao.org/regenerator-runtime/download/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
   integrity sha1-ysLazIoepnX+qrrriugziYrkb1U=


### PR DESCRIPTION
本地调试源代码时遇到 ts 报错
```js
TypeScript error in /muji/react-resume-site/src/pages/Editor.tsx(22,28):
'CodeMirror' refers to a value, but is being used as a type here. Did you mean 'typeof CodeMirror'?  TS2749

    20 |   const { templateStore } = useStores();
    21 |   const { isPreview, mdContent, setHtml } = templateStore;
  > 22 |   const editorRef = useRef<CodeMirror>(null);
       |                            ^
    23 |   // console.log(color, theme, '===editor');
    24 |   useEffect(() => {
    25 |     // 由于子元素是 useEffect 中初始化，因此正常无法获取，需要延迟
```