### PR TITLE
优化获取 editorRef 的方式

### DIFF
--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React, { useCallback } from "react";
 import CodeMirror, { IEditorInstance } from "@uiw/react-codemirror";
 import debounce from "lodash-es/debounce";
 import { useStores } from "@src/store";
@@ -19,20 +19,18 @@ let timerSave: TimerSave = null;
 const Editor: React.FC<Props> = observer((props) => {
   const { templateStore } = useStores();
   const { isPreview, mdContent, setHtml } = templateStore;
-  const editorRef = useRef<IEditorInstance>(null);
-  // console.log(color, theme, '===editor');
-  useEffect(() => {
-    // 由于子元素是 useEffect 中初始化，因此正常无法获取，需要延迟
-    setTimeout(() => {
-      setMdEditorRef(editorRef.current?.editor);
-    }, 0)
-  }, []);
+  
+  const setRefCallback = useCallback((node: IEditorInstance) => {
+    if (node?.editor) {
+      setMdEditorRef(node.editor)
+    }
+  }, [])
 
   return (
     <>
       <div className="rs-editor-cover" style={{ display: isPreview ? 'flex' : 'none' }}>预览中，不可编辑</div>
       <CodeMirror
-        ref={editorRef}
+        ref={setRefCallback}
         value={mdContent}
         options={{
           theme: "github-light",

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -7,19 +7,14 @@ import { LOCAL_STORE } from '@src/utils/const';
 import { observer } from "mobx-react";
 import "./Editor.less"
 
-
-interface Props {
-
-}
-
 type TimerSave = number | null;
 
 let timerSave: TimerSave = null;
 
-const Editor: React.FC<Props> = observer((props) => {
+const Editor: React.FC = observer(() => {
   const { templateStore } = useStores();
   const { isPreview, mdContent, setHtml } = templateStore;
-  
+
   const setRefCallback = useCallback((node: IEditorInstance) => {
     if (node?.editor) {
       setMdEditorRef(node.editor)


### PR DESCRIPTION
原本在 useEffect 中用 setTimeout 延迟获取 ref 的方式虽然有效，但感觉并不是特别的正确，因此改成 ref 回调的方式。

另外删去没有用到的 `interface Props`